### PR TITLE
MBL-77 divToP (1.2.1)

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -11,3 +11,4 @@ ratings:
   - src/**
 exclude_paths:
 - __tests__/**
+- ./*.js

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -9,3 +9,5 @@ engines:
 ratings:
   paths:
   - src/**
+exclude_paths:
+- __tests__/**

--- a/README
+++ b/README
@@ -18,3 +18,5 @@ screen size friendly way
 1.1.0 - Add simple validation scheme for model properties
 
 1.1.1 - Add `div` to tag whitelist for sanitize (required in comments).
+
+1.2 - dToP: adds Cheerio dependency, converts div tags from mobile client to p.

--- a/__tests__/text.test.js
+++ b/__tests__/text.test.js
@@ -29,3 +29,57 @@ describe('threadNames', () => {
     expect(actual).toBe(expected)
   })
 })
+
+describe('divToP', () => {
+  it('converts div to p', () => {
+    const expected = 'Wombats are great.<p>They poop square.</p>'
+    const unsafe = 'Wombats are great.<div>They poop square.</div>'
+    const actual = text.divToP(unsafe)
+    expect(actual).toBe(expected)
+  })
+
+  it('ignores strings where div is not present', () => {
+    const expected = '<p>I have divulged that you are divine.</p>'
+    const actual = text.divToP(expected)
+    expect(actual).toBe(expected)
+  })
+
+  it('does not remove child tags of a div', () => {
+    const expected = 'Wombats are great.<p>They <em>poop</em> square.</p>'
+    const unsafe = 'Wombats are great.<div>They <em>poop</em> square.</div>'
+    const actual = text.divToP(unsafe)
+    expect(actual).toBe(expected)
+  })
+})
+
+describe('sanitize', () => {
+  it('returns empty string if called without text', () => {
+    expect(text.sanitize()).toBe('')
+  })
+
+  it('returns empty string if whitelist is not an array', () => {
+    expect(text.sanitize('foo', {})).toBe('')
+  })
+
+  it('allows whitelist to be undefined', () => {
+    expect(text.sanitize('foo')).toBe('foo')
+  })
+
+  it('strips leading whitespace in paragraphs', () => {
+    expect(text.sanitize('<p>&nbsp;</p>')).toBe('<p></p>')
+  })
+
+  it('removes tags not on a whitelist', () => {
+    const expected = 'Wombats are great.<div>They poop square.</div>'
+    const unsafe = 'Wombats are great.<em>So great.</em><div>They poop square.</div>'
+    const actual = text.sanitize(unsafe, [ 'div' ])
+    expect(actual).toBe(expected)
+  })
+
+  it('removes attributes not on a whitelist', () => {
+    const expected = '<p id="wombat-data">Wombats are great.</p>'
+    const unsafe = '<p id="wombat-data" class="main-wombat">Wombats are great.</p>'
+    const actual = text.sanitize(unsafe, [ 'p' ], { p: [ 'id' ] })
+    expect(actual).toBe(expected)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hylo-utils",
-  "version": "1.1.1",
+  "version": "1.2.1",
   "description": "Utility code shared by hylo-node and hylo-redux.",
   "repository": {
     "type": "git",

--- a/src/text.js
+++ b/src/text.js
@@ -1,18 +1,30 @@
+import cheerio from 'cheerio'
 import marked from 'marked'
 import insane from 'insane'
 import truncHtml from 'trunc-html'
 import linkify from './linkify'
 import prettyDate from 'pretty-date'
 
-export function sanitize (text) {
+// Replace any div tag with p. Note that this drops all attributes from the tag.
+export function divToP (text) {
+  if (!text || typeof text !== 'string') return ''
+  const $ = cheerio.load(text)
+  $('div').replaceWith(function () {
+    return $('<p>' + $(this).html() + '</p>')
+  })
+  return $.html()
+}
+
+export function sanitize (text, whitelist, attrWhitelist) {
   if (!text) return ''
+  if (whitelist && !Array.isArray(whitelist)) return ''
 
   // remove leading &nbsp; (a side-effect of contenteditable)
-  var strippedText = text.replace(/<p>&nbsp;/gi, '<p>')
+  const strippedText = text.replace(/<p>&nbsp;/gi, '<p>')
 
   return insane(strippedText, {
-    allowedTags: ['a', 'br', 'div', 'em', 'li', 'ol', 'p', 'strong', 'ul' ],
-    allowedAttributes: {
+    allowedTags: whitelist || ['a', 'br', 'em', 'li', 'ol', 'p', 'strong', 'ul' ],
+    allowedAttributes: attrWhitelist || {
       'a': ['href', 'data-user-id', 'data-entity-type']
     }
   })

--- a/text.js
+++ b/text.js
@@ -4,12 +4,17 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.truncate = exports.increment = exports.markdown = undefined;
+exports.divToP = divToP;
 exports.sanitize = sanitize;
 exports.present = present;
 exports.appendInP = appendInP;
 exports.textLength = textLength;
 exports.humanDate = humanDate;
 exports.threadNames = threadNames;
+
+var _cheerio = require('cheerio');
+
+var _cheerio2 = _interopRequireDefault(_cheerio);
 
 var _marked = require('marked');
 
@@ -33,15 +38,26 @@ var _prettyDate2 = _interopRequireDefault(_prettyDate);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-function sanitize(text) {
+// Replace any div tag with p. Note that this drops all attributes from the tag.
+function divToP(text) {
+  if (!text || typeof text !== 'string') return '';
+  var $ = _cheerio2.default.load(text);
+  $('div').replaceWith(function () {
+    return $('<p>' + $(this).html() + '</p>');
+  });
+  return $.html();
+}
+
+function sanitize(text, whitelist, attrWhitelist) {
   if (!text) return '';
+  if (whitelist && !Array.isArray(whitelist)) return '';
 
   // remove leading &nbsp; (a side-effect of contenteditable)
   var strippedText = text.replace(/<p>&nbsp;/gi, '<p>');
 
   return (0, _insane2.default)(strippedText, {
-    allowedTags: ['a', 'br', 'div', 'em', 'li', 'ol', 'p', 'strong', 'ul'],
-    allowedAttributes: {
+    allowedTags: whitelist || ['a', 'br', 'em', 'li', 'ol', 'p', 'strong', 'ul'],
+    allowedAttributes: attrWhitelist || {
       'a': ['href', 'data-user-id', 'data-entity-type']
     }
   });


### PR DESCRIPTION
This:
  - [x] adds divToP to replace `div` tags created by the rich text editor on mobile client
  - [x] adds some tests for that and `sanitize`
  - [x] adds Cheerio as a dependency

See also https://github.com/Hylozoic/HyloReactNative/pull/59.